### PR TITLE
fix: add missing .cli suffix to metadata group

### DIFF
--- a/src/main/resources/metadata/cli.yaml
+++ b/src/main/resources/metadata/cli.yaml
@@ -1,4 +1,4 @@
-group: io.kestra.plugin.ansible
+group: io.kestra.plugin.ansible.cli
 name: "cli"
 title: "Ansible CLI"
 description: "Tasks that run Ansible CLI commands to execute playbooks and capture results."


### PR DESCRIPTION
## Summary
- `src/main/resources/metadata/cli.yaml` had `group: io.kestra.plugin.ansible` but the actual Java package is `io.kestra.plugin.ansible.cli`
- Fixed by appending `.cli` to the group value

## Test plan
- [ ] Verify `group` in `cli.yaml` matches `io.kestra.plugin.ansible.cli`