### PR TITLE
feat: auto-install requirements.txt and requirements.yml

### DIFF
--- a/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
+++ b/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
@@ -54,7 +54,10 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Run Ansible CLI commands",
-    description = "Executes ansible or ansible-playbook commands with the configured task runner. Generates ansible.cfg with the Kestra callback by default unless you supply one. Uses the cytopia/ansible:latest-tools image by default and merges outputs across multiple commands."
+    description = """
+        Executes ansible or ansible-playbook commands with the configured task runner. Generates ansible.cfg with the Kestra callback by default unless you supply one. Uses the cytopia/ansible:latest-tools image by default and merges outputs across multiple commands.
+        When a `requirements.txt` file is present in the working directory, the task automatically installs the listed Python packages with `pip` before running commands. When a `requirements.yml` file is present, it installs the listed Ansible Galaxy collections and roles with `ansible-galaxy install`. Both behaviors are enabled by default and can be disabled via `autoInstallPythonRequirements` and `autoInstallGalaxyRequirements`.
+        """
 )
 @Plugin(
     examples = {
@@ -222,6 +225,28 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
     @PluginProperty(group = "source")
     private Property<Boolean> outputLogFile = Property.ofValue(false);
 
+    @Schema(
+        title = "Auto-install Python dependencies",
+        description = """
+            If true (default), runs `pip install --no-cache-dir -r requirements.txt` before commands when a `requirements.txt` file is present in the working directory.
+            The check is performed at runtime in the runner shell, so the file may come from `inputFiles`, `namespaceFiles`, or any other source materialized into the working directory.
+            """
+    )
+    @Builder.Default
+    @PluginProperty(group = "execution")
+    protected Property<Boolean> autoInstallPythonRequirements = Property.ofValue(true);
+
+    @Schema(
+        title = "Auto-install Ansible Galaxy collections and roles",
+        description = """
+            If true (default), runs `ansible-galaxy install -r requirements.yml` before commands when a `requirements.yml` file is present in the working directory.
+            Since Ansible 2.10, `ansible-galaxy install` handles both the `collections:` and `roles:` keys defined in `requirements.yml`.
+            """
+    )
+    @Builder.Default
+    @PluginProperty(group = "execution")
+    protected Property<Boolean> autoInstallGalaxyRequirements = Property.ofValue(true);
+
     @PluginProperty(group = "source")
     private NamespaceFiles namespaceFiles;
 
@@ -268,6 +293,17 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
         );
         emitInventoryAssets(runContext, workingDir);
 
+        // Auto-install requirement files when present in the working directory.
+        // Shell-level conditionals so detection happens after working dir is materialized by the task runner.
+        // `[ ! -f X ] || cmd` — file absent: exits 0; file present: runs cmd and propagates its exit code.
+        List<String> autoInstallCommands = new ArrayList<>();
+        if (runContext.render(this.autoInstallPythonRequirements).as(Boolean.class).orElseThrow()) {
+            autoInstallCommands.add("[ ! -f requirements.txt ] || pip install --no-cache-dir -r requirements.txt");
+        }
+        if (runContext.render(this.autoInstallGalaxyRequirements).as(Boolean.class).orElseThrow()) {
+            autoInstallCommands.add("[ ! -f requirements.yml ] || ansible-galaxy install -r requirements.yml");
+        }
+
         List<String> rCommands = runContext.render(this.commands).asList(String.class, extraVars);
 
         // run each ansible-playbook separately and merge outputs
@@ -300,15 +336,20 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
                 perCommandLogs.add(logPath);
             }
 
+            Property<List<String>> mergedBeforeCommands = null;
+            if (!beforeDone) {
+                List<String> renderedBefore = runContext.render(this.beforeCommands).asList(String.class, extraVars);
+                // User beforeCommands run first so they can configure the environment
+                // (e.g. private pip index, proxy, auth) before auto-install fires.
+                List<String> merged = new ArrayList<>(renderedBefore);
+                merged.addAll(autoInstallCommands);
+                mergedBeforeCommands = Property.ofValue(merged);
+            }
+
             CommandsWrapper commandWrapper = baseWrapper
                 .withEnv(envForRun)
                 // run beforeCommands only once, before the first command (rendered with extra vars)
-                .withBeforeCommands(
-                    beforeDone ? null
-                        : Property.ofValue(
-                            runContext.render(this.beforeCommands).asList(String.class, extraVars)
-                        )
-                )
+                .withBeforeCommands(mergedBeforeCommands)
                 // single command per run so Kestra doesn't overwrite outputs
                 .withCommands(Property.ofValue(List.of(cmd)));
 

--- a/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
+++ b/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
@@ -681,6 +681,160 @@ class AnsibleCLITest {
     }
 
     @Test
+    void run_withRequirementsTxt_autoInstalls() throws Exception {
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .inputFiles(
+                Map.of(
+                    "requirements.txt", "proxmoxer==2.0.1\n"
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        // Will fail if proxmoxer was not pip-installed beforehand.
+                        "python -c \"import proxmoxer; print('proxmoxer imported')\""
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        ScriptOutput runOutput = execute.run(runContext);
+
+        assertThat(runOutput.getExitCode(), is(0));
+    }
+
+    @Test
+    void run_withRequirementsYml_autoInstalls() throws Exception {
+        // Use a Galaxy role rather than a collection: roles are never bundled with Ansible,
+        // so a successful `ansible-galaxy role list` for it proves the auto-install ran.
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .inputFiles(
+                Map.of(
+                    "requirements.yml", """
+                        ---
+                        roles:
+                          - name: geerlingguy.docker
+                        """
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        // Will fail (non-zero exit) if the role was not installed.
+                        "ansible-galaxy role list geerlingguy.docker"
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        ScriptOutput runOutput = execute.run(runContext);
+
+        assertThat(runOutput.getExitCode(), is(0));
+    }
+
+    @Test
+    void run_autoInstallGalaxyDisabled_skipsRoleInstall() throws Exception {
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .autoInstallGalaxyRequirements(Property.ofValue(false))
+            .inputFiles(
+                Map.of(
+                    "requirements.yml", """
+                        ---
+                        roles:
+                          - name: geerlingguy.docker
+                        """
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        // With auto-install disabled, the role must not be present.
+                        "ansible-galaxy role list geerlingguy.docker"
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        try {
+            ScriptOutput runOutput = execute.run(runContext);
+            // Some task runners surface failures via non-zero exitCode rather than throwing.
+            // AssertionError is an Error (not Exception), so a passing 0 still fails the test.
+            assertThat(runOutput.getExitCode(), is(not(0)));
+        } catch (Exception e) {
+            // Expected: command failed because the role is missing.
+        }
+    }
+
+    @Test
+    void run_autoInstallDisabled_skipsPipInstall() throws Exception {
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .autoInstallPythonRequirements(Property.ofValue(false))
+            .inputFiles(
+                Map.of(
+                    "requirements.txt", "proxmoxer==2.0.1\n"
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        // With auto-install disabled, proxmoxer is not installed and import must fail.
+                        "python -c \"import proxmoxer\""
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        try {
+            ScriptOutput runOutput = execute.run(runContext);
+            // Some task runners surface failures via non-zero exitCode rather than throwing.
+            // AssertionError is an Error (not Exception), so a passing 0 still fails the test.
+            assertThat(runOutput.getExitCode(), is(not(0)));
+        } catch (Exception e) {
+            // Expected: command failed because proxmoxer is missing.
+        }
+    }
+
+    @Test
     void shouldReproduceVaultSerializationBug() throws Exception {
 
         AnsibleCLI task = AnsibleCLI.builder()

--- a/src/test/java/io/kestra/plugin/ansible/cli/RunnerTest.java
+++ b/src/test/java/io/kestra/plugin/ansible/cli/RunnerTest.java
@@ -15,7 +15,7 @@ class RunnerTest {
     @Test
     @ExecuteFlow("sanity-checks/all_ansible.yaml")
     void all_ansible(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(5));
+        assertThat(execution.getTaskRunList(), hasSize(6));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/src/test/resources/sanity-checks/all_ansible.yaml
+++ b/src/test/resources/sanity-checks/all_ansible.yaml
@@ -6,6 +6,8 @@ tasks:
     type: io.kestra.plugin.ansible.cli.AnsibleCLI
     outputLogFile: true
     inputFiles:
+      requirements.txt: |
+        proxmoxer==2.0.1
       playbook.yml: |
         ---
         - hosts: localhost
@@ -13,6 +15,10 @@ tasks:
             - name: Print sanity message
               ansible.builtin.debug:
                 msg: "Hello from Ansible sanity check"
+
+            - name: Ensure auto-installed Python dep is importable
+              ansible.builtin.command: python -c "import proxmoxer"
+              changed_when: false
     commands:
       - ansible-playbook -i localhost -c local playbook.yml
 


### PR DESCRIPTION
## Summary
- Auto-detect `requirements.txt` / `requirements.yml` in working dir and install before commands.
- Default on; opt-out via `autoInstallPythonRequirements` / `autoInstallGalaxyRequirements`.
- Shell-conditional injection prepended to `beforeCommands`; visible in task logs.

Closes #74