### PR TITLE
fix(test): make galaxy skip-install test detect missing role reliably

### DIFF
--- a/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
+++ b/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
@@ -777,7 +777,9 @@ class AnsibleCLITest {
                 Property.ofValue(
                     List.of(
                         // With auto-install disabled, the role must not be present.
-                        "ansible-galaxy role list geerlingguy.docker"
+                        // `ansible-galaxy role list <role>` only warns (exit 0) when a role
+                        // is missing, so grep the listing to force a non-zero exit on absence.
+                        "ansible-galaxy role list 2>/dev/null | grep -q geerlingguy.docker"
                     )
                 )
             )


### PR DESCRIPTION
## What

Fixes the failing `AnsibleCLITest.run_autoInstallGalaxyDisabled_skipsRoleInstall` test on `main` ([failing run](https://github.com/kestra-io/plugin-ansible/actions/runs/27118365227/job/80029779050)).

## Why

The test disables `autoInstallGalaxyRequirements` and runs `ansible-galaxy role list geerlingguy.docker`, asserting a non-zero exit code to prove the role was not installed.

But `ansible-galaxy role list <role>` only emits warnings when the role is missing and still **exits 0**:

```
[WARNING]: None of the provided paths were usable. Please specify a valid path with --roles-path.
```

So the assertion `is(not(0))` never held:

```
java.lang.AssertionError:
Expected: is not <0>
     but: was <0>
```

This was a flawed test assumption — the plugin code correctly skipped the install; the test just couldn't detect it.

## How

Grep the role listing so a missing role forces a non-zero exit:

```java
"ansible-galaxy role list 2>/dev/null | grep -q geerlingguy.docker"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)