### PR TITLE
feat: show Ansible task logs under their own taskruns

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.5.2-SNAPSHOT
-kestraVersion=1.3.0
+kestraVersion=1.3.26

--- a/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
+++ b/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
@@ -32,6 +32,7 @@ import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.models.tasks.runners.TaskRunnerDetailResult;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AssetEmit;
+import io.kestra.core.runners.DynamicTaskRunLog;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.WorkerTaskResult;
 import io.kestra.core.serializers.JacksonMapper;
@@ -46,6 +47,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.slf4j.event.Level;
 
 @SuperBuilder
 @ToString
@@ -701,14 +703,14 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
     }
 
     /**
-     * Create dynamic TaskRuns per Ansible task so UI can render bars.
+     * Create one dynamic TaskRun per Ansible task and emit that task's host-result lines as logs
+     * tagged with the taskrun's id, so logs are attributed per Ansible task instead of all landing
+     * on the parent task's root taskrun (issue kestra-ee#8520).
      */
     private void emitDynamicTaskRuns(RunContext runContext, List<AnsibleOutput.PlaybookOutput> playbooks) throws IllegalVariableEvaluationException {
         if (playbooks == null || playbooks.isEmpty()) {
             return;
         }
-
-        List<WorkerTaskResult> results = new ArrayList<>();
 
         for (AnsibleOutput.PlaybookOutput pb : playbooks) {
             if (pb == null || pb.getPlays() == null)
@@ -759,35 +761,72 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
                     histories.add(new State.History(finalType, ended));
                     State state = State.of(finalType, histories);
 
-                    WorkerTaskResult wtr = WorkerTaskResult.builder()
-                        .taskRun(
-                            TaskRun.builder()
-                                .id(IdUtils.create())
-                                .namespace(runContext.render("{{ flow.namespace }}"))
-                                .flowId(runContext.render("{{ flow.id }}"))
-                                .taskId(uid) // stable identity for UI grouping
-                                .value(runContext.render("{{ taskrun.id }}"))
-                                .executionId(runContext.render("{{ execution.id }}"))
-                                .parentTaskRunId(runContext.render("{{ taskrun.id }}"))
-                                .state(state)
-                                .attempts(
-                                    List.of(
-                                        TaskRunAttempt.builder()
-                                            .state(state)
-                                            .build()
-                                    )
-                                )
-                                .build()
+                    TaskRun subTaskRun = TaskRun.builder()
+                        .id(IdUtils.create())
+                        .tenantId(runContext.flowInfo().tenantId())
+                        .namespace(runContext.render("{{ flow.namespace }}"))
+                        .flowId(runContext.render("{{ flow.id }}"))
+                        .taskId(uid) // stable identity for per-task grouping
+                        .executionId(runContext.render("{{ execution.id }}"))
+                        .parentTaskRunId(runContext.render("{{ taskrun.id }}"))
+                        .state(state)
+                        .attempts(
+                            List.of(
+                                TaskRunAttempt.builder()
+                                    .state(state)
+                                    .build()
+                            )
                         )
                         .build();
 
-                    results.add(wtr);
+                    // Register the dynamic taskrun together with its host-result log lines in one
+                    // call: the logs ride with the taskrun, so they can only attach to it, and the
+                    // run context fills in the execution/tenant context, fixes the attempt and masks
+                    // secrets (the plugin never builds a LogEntry).
+                    runContext.dynamicWorkerResult(
+                        WorkerTaskResult.builder().taskRun(subTaskRun).build(),
+                        taskLogs(task)
+                    );
                 }
             }
         }
+    }
 
-        if (!results.isEmpty()) {
-            runContext.dynamicWorkerResult(results);
+    /**
+     * Build the host-result log lines for a task. In EXPLICIT outputs mode the host result payload is
+     * already redacted by the callback.
+     */
+    private List<DynamicTaskRunLog> taskLogs(AnsibleOutput.TaskOutput task) {
+        if (task.getHosts() == null) {
+            return List.of();
+        }
+
+        List<DynamicTaskRunLog> logs = new ArrayList<>();
+        for (AnsibleOutput.HostResult hr : task.getHosts()) {
+            if (hr == null) {
+                continue;
+            }
+
+            String status = hr.getStatus();
+            boolean failed = "failed".equalsIgnoreCase(status) || "unreachable".equalsIgnoreCase(status);
+            logs.add(new DynamicTaskRunLog(
+                failed ? Level.ERROR : Level.INFO,
+                "[" + hr.getHost() + "] " + status + " => " + stringifyResult(hr.getResult())
+            ));
+        }
+
+        return logs;
+    }
+
+    private static String stringifyResult(Object result) {
+        if (result == null) {
+            return "{}";
+        }
+
+        try {
+            return JacksonMapper.ofJson().writeValueAsString(result);
+        } catch (Exception e) {
+            return String.valueOf(result);
         }
     }
 

--- a/src/main/resources/callback_plugins/kestra_logger.py
+++ b/src/main/resources/callback_plugins/kestra_logger.py
@@ -198,10 +198,10 @@ class CallbackModule(CallbackBase):
 
         json_line = json.dumps(task_payload, default=str, separators=(",", ":"))
 
-        # stdout for Kestra live parsing
-        print(json_line)
-
-        # same line in log_path with timestamp prefix
+        # Do NOT print the per-task line to stdout: it would be captured on the parent task's
+        # root taskrun. Per-task data reaches Kestra via the final structured payload
+        # (see _log_kestra_outputs), which AnsibleCLI turns into logs attributed to each task's
+        # own taskrun (issue kestra-ee#8520). We still write it to log_path for `outputLogFile`.
         ts = ended_at_dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         self._write_log_line(f"{ts} {json_line}")
 

--- a/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
+++ b/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
@@ -5,7 +5,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.queues.QueueFactoryInterface;
@@ -45,6 +47,10 @@ class AnsibleCLITest {
 
     @Inject
     private TestAssetManagerFactory assetManagerFactory;
+
+    @Inject
+    @Named(QueueFactoryInterface.WORKERTASKLOG_NAMED)
+    private QueueInterface<LogEntry> logQueue;
 
     @Test
     void extractInventoryAssetInputs_shouldParseHostsAsInputsOnly() {
@@ -453,6 +459,65 @@ class AnsibleCLITest {
         List<String> additionalMessages = (List<String>) t6res.get("msg");
         assertThat(additionalMessages.size(), is(2));
         assertThat(additionalMessages, containsInAnyOrder("Multiline message : line 3", "Multiline message : line 4"));
+    }
+
+    @Test
+    void run_emitsLogsUnderDynamicTaskRuns() throws Exception {
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .inputFiles(
+                Map.of(
+                    "playbooks/playbook.yml", storage.put(
+                        TenantService.MAIN_TENANT,
+                        null,
+                        URI.create("/" + IdUtils.create() + ".ion"),
+                        this.getClass().getClassLoader().getResourceAsStream("playbooks/playbook.yml")
+                    ).toString()
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of("ansible-playbook -i localhost -c local playbooks/playbook.yml")
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        List<LogEntry> logs = new CopyOnWriteArrayList<>();
+        Flux<LogEntry> receive = TestsUtils.receive(logQueue, l -> logs.add(l.getLeft()));
+
+        AnsibleCLI.AnsibleOutput runOutput = execute.run(runContext);
+        assertThat(runOutput.getExitCode(), is(0));
+
+        // Each Ansible task produces a dynamic taskrun (issue kestra-ee#8520): its host results
+        // must be emitted as logs tagged with the dynamic taskrun id, not the parent root.
+        Set<String> dynamicTaskRunIds = runContext.dynamicWorkerResults().stream()
+            .map(r -> r.getTaskRun().getId())
+            .collect(Collectors.toSet());
+        assertThat(dynamicTaskRunIds, is(not(empty())));
+
+        TestsUtils.awaitLog(logs, l -> l.getTaskRunId() != null && dynamicTaskRunIds.contains(l.getTaskRunId()));
+        receive.blockLast();
+
+        List<LogEntry> dynamicLogs = List.copyOf(logs).stream()
+            .filter(l -> l.getTaskRunId() != null && dynamicTaskRunIds.contains(l.getTaskRunId()))
+            .toList();
+
+        // logs are attributed to each task's dynamic taskrun, all on the single localhost host
+        assertThat(dynamicLogs, is(not(empty())));
+        assertThat(dynamicLogs.stream().allMatch(l -> l.getMessage() != null && l.getMessage().contains("[localhost]")), is(true));
+        assertThat(dynamicLogs.stream().anyMatch(l -> l.getMessage().contains("[localhost] ok")), is(true));
+        // attemptNumber MUST be 0: logs are grouped per taskrun by (taskRunId, attemptNumber) and a
+        // single-attempt taskrun's logs live under attempt 0
+        assertThat(dynamicLogs.stream().allMatch(l -> l.getAttemptNumber() != null && l.getAttemptNumber() == 0), is(true));
     }
 
     @Test


### PR DESCRIPTION
Fixes [kestra-ee#8520](https://github.com/kestra-io/kestra-ee/issues/8520). Each Ansible play/task already produced a dynamic taskrun (timeline bar) but carried no logs — all output was dumped on the parent task's root taskrun.

- Emits each task's per-host results as logs attached to its dynamic taskrun, via the new single-call core API `dynamicWorkerResult(WorkerTaskResult, List<DynamicTaskRunLog>)`, so logs group under each task; ERROR level for failed/unreachable hosts. Respects EXPLICIT outputs mode (reads the already-redacted host result).
- Drops the redundant `value` on the dynamic taskruns (it was the parent taskrun id, which surfaced as a meaningless UUID subtitle in the Gantt/Logs views).
- The bundled callback no longer prints the per-task line to stdout (it duplicated content on the root taskrun); the structured outputs payload still carries everything.
- Extended `AnsibleCLITest`.

Companion to (and depends on) the core PR kestra-io/kestra#16898 — needs a core release that includes the new `dynamicWorkerResult` logs overload.