### PR TITLE
Documentation review: plugin-ansible

### DIFF
--- a/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
+++ b/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
@@ -64,7 +64,7 @@ import org.slf4j.event.Level;
 @Plugin(
     examples = {
         @Example(
-            title = "Execute a list of Ansible CLI commands to orchestrate an Ansible playbook stored in the Editor using [Namespace Files](https://kestra.io/docs/developer-guide/namespace-files).",
+            title = "Execute a list of Ansible CLI commands to orchestrate an Ansible playbook stored in the Editor using [Namespace Files](https://kestra.io/docs/concepts/namespace-files).",
             full = true,
             code = """
                 id: ansible


### PR DESCRIPTION
## Documentation review: plugin-ansible

Documentation-only pass over the single task (`cli.AnsibleCLI`), both `package-info` subgroup
descriptions, the plugin how-to doc, and metadata. Task inventory cross-checked against the Kestra
plugin registry (1 task, matches). No behavior, validation, or UI-layout changes.

The plugin was in excellent shape — 5 clear, valid examples; fully-documented nested outputs
(`playbooks` → plays → tasks → host results); accurate `outputsMode`/auto-install descriptions;
consistent `package-info`/metadata. One fix:

- **`AnsibleCLI` example 1 linked to a stale docs URL:** `https://kestra.io/docs/developer-guide/namespace-files`
  → `https://kestra.io/docs/concepts/namespace-files` (verified as the canonical path via the Kestra
  docs API; the plugin's how-to doc already used the correct URL).
