### PR TITLE
fix(cli): make kestra_logger callback discoverable regardless of playbook path

### DIFF
--- a/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
+++ b/src/main/java/io/kestra/plugin/ansible/cli/AnsibleCLI.java
@@ -17,6 +17,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.slf4j.event.Level;
+
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -47,7 +49,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.slf4j.event.Level;
 
 @SuperBuilder
 @ToString
@@ -231,6 +232,15 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
     private static final String VM_ASSET_TYPE = "io.kestra.plugin.ee.assets.VM";
     private static final Pattern ASSET_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9][a-zA-Z0-9._-]*$");
 
+    // Ensure Ansible can find our bundled callback/library dirs regardless of where the playbook
+    // lives or what the image configures (issue #120). Prepend them onto the search path using the
+    // runtime working dir ($PWD, the current directory on every runner), keeping any existing value
+    // so an image's own callback (e.g. ARA) still loads.
+    private static final List<String> CALLBACK_PATH_EXPORTS = List.of(
+        "export ANSIBLE_CALLBACK_PLUGINS=\"$PWD/callback_plugins${ANSIBLE_CALLBACK_PLUGINS:+:$ANSIBLE_CALLBACK_PLUGINS}\"",
+        "export ANSIBLE_LIBRARY=\"$PWD/library${ANSIBLE_LIBRARY:+:$ANSIBLE_LIBRARY}\""
+    );
+
     @Schema(
         title = "Run once before commands",
         description = "Optional shell commands executed only before the first main command, rendered with the same variables."
@@ -283,6 +293,7 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
         description = """
             If omitted, a generated ansible.cfg in the working directory enables the Kestra callback plugin and logs to `log`.
             Provide custom content to override defaults; include the callback settings above if you still want structured outputs.
+            To guarantee output capture regardless of the playbook location or the image, the task also pins its bundled callback and module directories via the `ANSIBLE_CALLBACK_PLUGINS` and `ANSIBLE_LIBRARY` environment variables, keeping any value already set on those variables. If you use your own callbacks or modules, set their paths through the task's `env` (they are preserved and load alongside the Kestra ones). A callback or module path configured only in a custom `ansible.cfg` is superseded by these variables, so set it via `env` instead.
             """
     )
     @Builder.Default
@@ -436,19 +447,21 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
                 perCommandLogs.add(logPath);
             }
 
-            Property<List<String>> mergedBeforeCommands = null;
+            // First (before any user `cd`, so $PWD is the working-dir root) and on every command
+            // (each runs in its own container).
+            List<String> beforeForRun = new ArrayList<>(CALLBACK_PATH_EXPORTS);
             if (!beforeDone) {
-                List<String> renderedBefore = runContext.render(this.beforeCommands).asList(String.class, extraVars);
-                // User beforeCommands run first so they can configure the environment
+                // User beforeCommands can configure the environment
                 // (e.g. private pip index, proxy, auth) before auto-install fires.
-                List<String> merged = new ArrayList<>(renderedBefore);
-                merged.addAll(autoInstallCommands);
-                mergedBeforeCommands = Property.ofValue(merged);
+                beforeForRun.addAll(runContext.render(this.beforeCommands).asList(String.class, extraVars));
+                beforeForRun.addAll(autoInstallCommands);
             }
+            Property<List<String>> mergedBeforeCommands = Property.ofValue(beforeForRun);
 
             CommandsWrapper commandWrapper = baseWrapper
                 .withEnv(envForRun)
-                // run beforeCommands only once, before the first command (rendered with extra vars)
+                // user beforeCommands + auto-install run once before the first command; the callback
+                // path exports are re-applied before every command (each runs in its own container)
                 .withBeforeCommands(mergedBeforeCommands)
                 // single command per run so Kestra doesn't overwrite outputs
                 .withCommands(Property.ofValue(List.of(cmd)));
@@ -809,10 +822,12 @@ public class AnsibleCLI extends Task implements RunnableTask<AnsibleCLI.AnsibleO
 
             String status = hr.getStatus();
             boolean failed = "failed".equalsIgnoreCase(status) || "unreachable".equalsIgnoreCase(status);
-            logs.add(new DynamicTaskRunLog(
-                failed ? Level.ERROR : Level.INFO,
-                "[" + hr.getHost() + "] " + status + " => " + stringifyResult(hr.getResult())
-            ));
+            logs.add(
+                new DynamicTaskRunLog(
+                    failed ? Level.ERROR : Level.INFO,
+                    "[" + hr.getHost() + "] " + status + " => " + stringifyResult(hr.getResult())
+                )
+            );
         }
 
         return logs;

--- a/src/main/resources/doc/io.kestra.plugin.ansible.md
+++ b/src/main/resources/doc/io.kestra.plugin.ansible.md
@@ -9,3 +9,16 @@ Run Ansible playbooks and ad-hoc commands from Kestra flows inside a container w
 ## Tasks
 
 `cli.AnsibleCLI` runs one or more Ansible CLI commands set in `commands` (e.g. `ansible-playbook site.yml -i inventory.ini`). Use `beforeCommands` to run setup steps before the main commands, `env` to inject environment variables, and `outputFiles` to capture files produced during execution. Set `ansibleConfig` to supply a custom `ansible.cfg`; if omitted, Kestra generates one automatically with its structured output callback enabled.
+
+## Output capture and custom callbacks
+
+The task captures each playbook's results into `outputs.<taskId>.vars.outputs` and `outputs.<taskId>.vars.playbooks` through a bundled Ansible callback (`kestra_logger`). Ansible loads that callback only if it can find it on its callback search path, so the task adds its bundled callback and module directories to `ANSIBLE_CALLBACK_PLUGINS` and `ANSIBLE_LIBRARY` before running commands. This keeps outputs working even when the playbook is in a subdirectory (e.g. `ansible-playbook ansible/site.yml`) or the runner image sets its own callback path (e.g. ARA-instrumented images).
+
+Any value already present on those environment variables is preserved, so your own callbacks or modules keep loading alongside the Kestra ones. If you use your own callbacks or modules, set their paths through the task's `env`:
+
+```yaml
+env:
+  ANSIBLE_CALLBACK_PLUGINS: "/opt/mycallbacks"   # loads alongside Kestra's
+```
+
+Limitation: a callback or module path configured only in a custom `ansible.cfg` (and not via the environment) is superseded by these variables, because in Ansible an environment variable overrides the config file. If you rely on such a path, set it via the task's `env` as shown above so it is preserved.

--- a/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
+++ b/src/test/java/io/kestra/plugin/ansible/cli/AnsibleCLITest.java
@@ -4,22 +4,19 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
-import io.kestra.core.models.executions.LogEntry;
-import io.kestra.core.queues.QueueFactoryInterface;
-import io.kestra.core.queues.QueueInterface;
-import io.kestra.plugin.scripts.runner.docker.PullPolicy;
-import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.assets.AssetIdentifier;
 import io.kestra.core.models.assets.AssetsDeclaration;
+import io.kestra.core.models.executions.LogEntry;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.queues.QueueFactoryInterface;
+import io.kestra.core.queues.QueueInterface;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
@@ -29,8 +26,10 @@ import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.runner.docker.PullPolicy;
 
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import reactor.core.publisher.Flux;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -1061,59 +1060,69 @@ class AnsibleCLITest {
         AnsibleCLI task = AnsibleCLI.builder()
             .id(IdUtils.create())
             .type(AnsibleCLI.class.getName())
-            .beforeCommands(Property.ofValue(List.of(
-                "pip install --default-timeout=60 \"ansible>=9,<10\""
-            )))
-            .inputFiles(Map.of(
+            .beforeCommands(
+                Property.ofValue(
+                    List.of(
+                        "pip install --default-timeout=60 \"ansible>=9,<10\""
+                    )
+                )
+            )
+            .inputFiles(
+                Map.of(
 
-                "inventory.ini",
-                """
-                [target]
-                localhost ansible_connection=local
-                """,
+                    "inventory.ini",
+                    """
+                        [target]
+                        localhost ansible_connection=local
+                        """,
 
-                "vault_vars.yml",
-                """
-                vault_secret_value: !vault |
-                  $ANSIBLE_VAULT;1.1;AES256
-                  35363665656162366638396161616466313965383938313366633734306266633433333265313862
-                  3633646532336664623966666663386531363262336638360a363033373931376432393761613163
-                  35346336383665626335346134613638663561373230616631623538313636306332383431363637
-                  6665623938653066390a396563323430326335303164626661623064313234333633313431613666
-                  65666131633031653630393066383663373630666532383164303837663735393030
-                """,
+                    "vault_vars.yml",
+                    """
+                        vault_secret_value: !vault |
+                          $ANSIBLE_VAULT;1.1;AES256
+                          35363665656162366638396161616466313965383938313366633734306266633433333265313862
+                          3633646532336664623966666663386531363262336638360a363033373931376432393761613163
+                          35346336383665626335346134613638663561373230616631623538313636306332383431363637
+                          6665623938653066390a396563323430326335303164626661623064313234333633313431613666
+                          65666131633031653630393066383663373630666532383164303837663735393030
+                        """,
 
-                "playbook.yml",
-                """
-                ---
-                - name: Reproduce vault serialization bug
-                  hosts: target
-                  gather_facts: false
-                  tasks:
-                    - name: Hello world
-                      ansible.builtin.debug:
-                        msg: Hello!!
+                    "playbook.yml",
+                    """
+                        ---
+                        - name: Reproduce vault serialization bug
+                          hosts: target
+                          gather_facts: false
+                          tasks:
+                            - name: Hello world
+                              ansible.builtin.debug:
+                                msg: Hello!!
 
-                    - name: Load vault-encrypted vars at runtime
-                      ansible.builtin.include_vars:
-                        file: vault_vars.yml
+                            - name: Load vault-encrypted vars at runtime
+                              ansible.builtin.include_vars:
+                                file: vault_vars.yml
 
-                    - name: Use vault-encrypted variable in a task
-                      ansible.builtin.debug:
-                        msg: "Vault value is {{ '{{' }} vault_secret_value {{ '}}' }}"
+                            - name: Use vault-encrypted variable in a task
+                              ansible.builtin.debug:
+                                msg: "Vault value is {{ '{{' }} vault_secret_value {{ '}}' }}"
 
-                    - name: Set fact from vault-encrypted variable
-                      ansible.builtin.set_fact:
-                        derived_value: "{{ '{{' }} vault_secret_value {{ '}}' }}"
+                            - name: Set fact from vault-encrypted variable
+                              ansible.builtin.set_fact:
+                                derived_value: "{{ '{{' }} vault_secret_value {{ '}}' }}"
 
-                    - name: Use derived vault fact
-                      ansible.builtin.debug:
-                        msg: "Derived value is {{ '{{' }} derived_value {{ '}}' }}"
-                """
-            ))
-            .commands(Property.ofValue(List.of(
-                "echo \"bugreport\" > /tmp/vault_pass.txt && ansible-playbook -i inventory.ini --vault-password-file /tmp/vault_pass.txt playbook.yml"
-            )))
+                            - name: Use derived vault fact
+                              ansible.builtin.debug:
+                                msg: "Derived value is {{ '{{' }} derived_value {{ '}}' }}"
+                        """
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        "echo \"bugreport\" > /tmp/vault_pass.txt && ansible-playbook -i inventory.ini --vault-password-file /tmp/vault_pass.txt playbook.yml"
+                    )
+                )
+            )
 
             .taskRunner(
                 io.kestra.plugin.scripts.runner.docker.Docker.builder()
@@ -1131,5 +1140,119 @@ class AnsibleCLITest {
         assertThat(output.getPlaybooks(), is(notNullValue()));
         assertThat(output.getPlaybooks().getFirst().getPlays(), is(notNullValue()));
 
+    }
+
+    // issue #120: subdirectory playbook + image-set ANSIBLE_CALLBACK_PLUGINS must still capture outputs.
+    @Test
+    @SuppressWarnings("unchecked")
+    void run_capturesOutputs_whenPlaybookInSubdir_andImageOverridesCallbackPath_issue120() throws Exception {
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .env(Property.ofValue(Map.of("ANSIBLE_CALLBACK_PLUGINS", "/tmp/othercb")))
+            .beforeCommands(Property.ofValue(List.of("mkdir -p /tmp/othercb")))
+            .inputFiles(
+                Map.of(
+                    "inventory.ini",
+                    "localhost ansible_connection=local",
+
+                    "ansible/playbook.yml",
+                    """
+                        ---
+                        - hosts: localhost
+                          gather_facts: false
+                          tasks:
+                            - name: Report serial number
+                              ansible.builtin.debug:
+                                msg:
+                                  serial_number: "SN-12345"
+                        """
+                )
+            )
+            .commands(
+                Property.ofValue(
+                    List.of(
+                        "ansible-playbook -i inventory.ini ansible/playbook.yml"
+                    )
+                )
+            )
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        AnsibleCLI.AnsibleOutput runOutput = execute.run(runContext);
+
+        assertThat(runOutput.getExitCode(), is(0));
+
+        List<Map<String, Object>> outputs = (List<Map<String, Object>>) runOutput.getVars().get("outputs");
+        assertThat(outputs, is(not(empty())));
+
+        Map<String, Object> msg = (Map<String, Object>) outputs.getFirst().get("msg");
+        assertThat(msg.get("serial_number"), is("SN-12345"));
+
+        assertThat(runOutput.getPlaybooks(), is(not(empty())));
+    }
+
+    // issue #120: defining assets must not affect output capture; both must work in the same run.
+    @Test
+    @SuppressWarnings("unchecked")
+    void run_capturesOutputs_andEmitsAssets_together_issue120() throws Exception {
+        assetManagerFactory.reset();
+
+        AnsibleCLI execute = AnsibleCLI.builder()
+            .id(IdUtils.create())
+            .type(AnsibleCLI.class.getName())
+            .docker(
+                DockerOptions.builder()
+                    .image("cytopia/ansible:latest-tools")
+                    .entryPoint(Collections.emptyList())
+                    .build()
+            )
+            .assets(new AssetsDeclaration(true, null, null))
+            .inputFiles(
+                Map.of(
+                    "inventory.ini",
+                    "[all]\nlocalhost ansible_connection=local\n",
+
+                    "playbook.yml",
+                    """
+                        ---
+                        - hosts: all
+                          gather_facts: false
+                          tasks:
+                            - name: Report serial number
+                              ansible.builtin.debug:
+                                msg:
+                                  serial_number: "SN-12345"
+                        """
+                )
+            )
+            .commands(Property.ofValue(List.of("ansible-playbook -i inventory.ini playbook.yml")))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, execute, Map.of());
+
+        AnsibleCLI.AnsibleOutput runOutput = execute.run(runContext);
+
+        // outputs are captured even though assets are defined
+        assertThat(runOutput.getExitCode(), is(0));
+        List<Map<String, Object>> outputs = (List<Map<String, Object>>) runOutput.getVars().get("outputs");
+        assertThat(outputs, is(not(empty())));
+        Map<String, Object> msg = (Map<String, Object>) outputs.getFirst().get("msg");
+        assertThat(msg.get("serial_number"), is("SN-12345"));
+
+        // and the asset is emitted alongside, in the same run
+        var emitted = assetManagerFactory.emitter().emitted();
+        assertThat(emitted.size(), is(1));
+        assertThat(
+            emitted.getFirst().inputs().stream().map(AssetIdentifier::id).toList(),
+            contains("localhost")
+        );
     }
 }


### PR DESCRIPTION
Closes #120.

**Problem:** a successful `AnsibleCLI` run returned empty `vars.outputs`/`vars.playbooks` when the playbook ran from a subdirectory and the image set `ANSIBLE_CALLBACK_PLUGINS` (e.g. ARA). Both drop the plugin's `callback_plugins/` off Ansible's search path, so the `kestra_logger` callback never loads.

**Fix:** pin the callback and library dirs onto the search path before commands run, keeping any existing value:

```
export ANSIBLE_CALLBACK_PLUGINS="$PWD/callback_plugins${ANSIBLE_CALLBACK_PLUGINS:+:$ANSIBLE_CALLBACK_PLUGINS}"
export ANSIBLE_LIBRARY="$PWD/library${ANSIBLE_LIBRARY:+:$ANSIBLE_LIBRARY}"
```

Regression test added. `AnsibleCLITest` passes (19 tests).